### PR TITLE
Avoid duplicate resource errors for packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,17 +38,17 @@ class bash (
     default        => '\[\033[31m\]',
   }
 
-  if $bashpackage {
-    package { $bashpackage:
+  if $bashpackage and ! defined(Package['bash']) {
+    ensure_packages([$bashpackage], {
       ensure => $ensure,
       alias  => 'bash',
-    }
+    })
   }
 
   if $bashcompletionpackage {
-    package { $bashcompletionpackage:
+    ensure_packages([$bashcompletionpackage], {
       ensure => $ensure,
-    }
+    })
   }
 
   file {


### PR DESCRIPTION
A few other modules install bash directly. This switches to using `ensure_packages` to avoid duplicate resource errors.