### PR TITLE
Fix infinite loop for shell sourcing on RHEL systems

### DIFF
--- a/files/bashrc.sh
+++ b/files/bashrc.sh
@@ -5,10 +5,15 @@
 # On Debian, /etc/bash.bashrc is already loaded by /etc/profile, but
 # /etc/bashrc doesn't exist, so this is a no-op.
 #
+# On CentOS/RHEL bashrc sources /etc/profile.d so sourcing 
+# /etc/bashrc here creates and infinite loop.
+#
 # On OS X, /etc/profile.d isn't searched.
 #
 # On Solaris, /etc/profile.d isn't searched, and /etc/bashrc doesn't exist.
 
-if [ "$PS1" -a -n "$BASH" -a "$BASH" != "/bin/sh" -a -r /etc/bashrc ]; then
-  source /etc/bashrc
+if [ ! -f "/etc/redhat-release" ] ; then 
+  if [ "$PS1" -a -n "$BASH" -a "$BASH" != "/bin/sh" -a -r /etc/bashrc ]; then
+    source /etc/bashrc
+  fi
 fi


### PR DESCRIPTION
Prior to this commit, any non-root user when running `bash` on the cli would get a segfault. This happens because `/etc/bashrc` sources `/etc/profile.d/*.sh` and this file in there source `/etc/bashrc` and you can see we've now created a loop. This just checks if you're on RH and does nothing if that's the case since `/etc/bashrc` will have already been sourced.