### PR TITLE
(INFC-19257) Revert "Fix infinite loop for shell sourcing on RHEL systems"

### DIFF
--- a/files/bashrc.sh
+++ b/files/bashrc.sh
@@ -5,15 +5,10 @@
 # On Debian, /etc/bash.bashrc is already loaded by /etc/profile, but
 # /etc/bashrc doesn't exist, so this is a no-op.
 #
-# On CentOS/RHEL bashrc sources /etc/profile.d so sourcing
-# /etc/bashrc here creates and infinite loop.
-#
 # On OS X, /etc/profile.d isn't searched.
 #
 # On Solaris, /etc/profile.d isn't searched, and /etc/bashrc doesn't exist.
 
-if  [ "$(facter osfamily)" != "RedHat" ] ; then
-  if [ "$PS1" -a -n "$BASH" -a "$BASH" != "/bin/sh" -a -r /etc/bashrc ]; then
-    source /etc/bashrc
-  fi
+if [ "$PS1" -a -n "$BASH" -a "$BASH" != "/bin/sh" -a -r /etc/bashrc ]; then
+  source /etc/bashrc
 fi


### PR DESCRIPTION
This reverts commit c3e95b75045cb8725ba702eb718e2e468d9e8819.

After rolling this out I discovered that prompts were busted and that
/etc/bashrc was never being sourced.